### PR TITLE
Strict RFC Email Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/pdepend
 build/phpdox
 coverage/
 vendor/
+.idea

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "php": ">=5.4",
         "wearebase/base-core": "1.0.*",
         "symfony/serializer": "2.5.*",
-        "symfony/validator": "2.5.*"
+        "symfony/validator": "2.5.*",
+        "egulias/email-validator": "~1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,112 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cd850d0c4fe3de6fc0bebc396ef4cbc2",
+    "hash": "3e0e1c20a2d2537c66c3e38d99a8d1e6",
     "packages": [
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09 13:34:57"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "af9417f765623429c9d2a200f0159537e08d1ef3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/af9417f765623429c9d2a200f0159537e08d1ef3",
+                "reference": "af9417f765623429c9d2a200f0159537e08d1ef3",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "~1.0",
+                "php": ">= 5.3.3"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "dev-master"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Egulias\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "validation",
+                "validator"
+            ],
+            "time": "2015-01-04 22:42:32"
+        },
         {
             "name": "symfony/serializer",
             "version": "v2.5.5",
@@ -978,18 +1082,13 @@
             "time": "2014-09-22 09:14:18"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.4"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/resources/validation.yml
+++ b/resources/validation.yml
@@ -7,6 +7,7 @@ Base\User\Entities\User:
             - Email:
                 message: 'validation.email.invalid'
                 groups: ['registration', 'deletion']
+                strict: true
         password:
             - NotBlank:
                 message: 'validation.password.blank'

--- a/src/Normalizers/UserNormalizer.php
+++ b/src/Normalizers/UserNormalizer.php
@@ -13,7 +13,7 @@ class UserNormalizer extends SerializerAwareNormalizer implements NormalizerInte
     public function normalize($object, $format = null, array $context = [])
     {
         $data = [
-            'email' => $object->getEmail(),
+            'email' => trim($object->getEmail()),
             'password' => $object->getPassword(),
             'roles' => $object->getRoles(),
             'associations' => $object->getAssociations(),

--- a/tests/Entities/UserTest.php
+++ b/tests/Entities/UserTest.php
@@ -58,6 +58,35 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $this->assertNotCount(0, $errors);
         $this->assertEquals('validation.email.invalid', $errors[0]->getMessage());
 
+        // Email address with spaces
+        $user = new User();
+        $user->setEmail('hello. world@devba. se');
+        $errors = $validator->validate($user, 'registration');
+        $this->assertNotCount(0, $errors);
+        $this->assertEquals('validation.email.invalid', $errors[0]->getMessage());
+
+        // Email address with invalid characters
+        $user = new User();
+        $user->setEmail('a"b(c)d,e:f;g<h>i[j\k]l@example.com');
+        $errors = $validator->validate($user, 'registration');
+        $this->assertNotCount(0, $errors);
+        $this->assertEquals('validation.email.invalid', $errors[0]->getMessage());
+
+        // Email address with escaped spaces
+        $user = new User();
+        $user->setEmail('this\\ still\\"not\\\\allowed@example.com');
+        $errors = $validator->validate($user, 'registration');
+        $this->assertNotCount(0, $errors);
+        $this->assertEquals('validation.email.invalid', $errors[0]->getMessage());
+
+        // Email address with valid characters
+        $user = new User();
+        $user->setPassword('password1');
+        $user->setConfirm('password1');
+        $user->setEmail("#!$%&'*+-/=?^_`{}|~@example.org");
+        $errors = $validator->validate($user, 'registration');
+        $this->assertCount(0, $errors);
+
         // Blank password
         $user = new User();
         $user->setEmail('example@devba.se');

--- a/tests/Normalizers/UserNormalizerTest.php
+++ b/tests/Normalizers/UserNormalizerTest.php
@@ -32,6 +32,16 @@ class UserNormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->getNormalized(), $data);
     }
 
+    public function testTrimEmailNormalize()
+    {
+        $user = new User();
+        $user->setEmail(' tester@devba.se ');
+        $user->setPassword('password');
+        $user->addExtension('favouriteStops', ['3390Y4', '3390Y3']);
+        $data = $this->serializer->normalize($user);
+        $this->assertEquals($this->getNormalized(), $data);
+    }
+
     public function testDenormalize()
     {
         $user = $this->serializer->denormalize($this->getNormalized(), 'Base\\User\\Entities\\User');


### PR DESCRIPTION
The Symfony simple regex allowed spaces in the domain part and unescaped spaces in the the local part. Enabling Symfony's strict email validation requires the egulias/email-validator library.

Previously it was using a simple regex. See: https://github.com/symfony/Validator/blob/master/Constraints/EmailValidator.php#L84
