### PR TITLE
Relax Postcode Validation

### DIFF
--- a/resources/validation.yml
+++ b/resources/validation.yml
@@ -50,9 +50,6 @@ Base\User\Entities\PersonalDetails:
         postcode:
             - NotBlank:
                 message: 'validation.postcode.blank'
-            - Regex:
-                pattern: '/GIR[ ]?0AA|((AB|AL|B|BA|BB|BD|BH|BL|BN|BR|BS|BT|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(\d[\dA-Z]?[ ]?\d[ABD-HJLN-UW-Z]{2}))|BFPO[ ]?\d{1,4}/i'
-                message: 'validation.postCode.invalid'
         phoneNumber:
             - NotBlank:
                 message: 'validation.phoneNumber.blank'

--- a/tests/Entities/PersonalDetailsTest.php
+++ b/tests/Entities/PersonalDetailsTest.php
@@ -96,15 +96,12 @@ class PersonalDetailsTest extends \PHPUnit_Framework_TestCase
     public function postCodeProvider()
     {
         return [
+            ['', true],
+            [null, true],
             ['CW3 9SS', false],
-            ['SE5 0EG', false],
-            ['SE50EG', false],
-            ['SE5 0EG', false],
-            ['WC2H 7LT', false],
-            ['bh4 9ae', false],
-            ['WCC 7LT', true],
-            ['WC2 777', true],
-            ['WC2H', true],
+            ['WCC 7LT', false],
+            ['WC2H', false],
+            ['7250', false],
         ];
     }
 }


### PR DESCRIPTION
Removes the regex that only covers UK based postcodes as users are
allowed to select a valid county optiona that is "outside of the UK".

We could integrate with an external web service or introduce regexes
that cover international addresses but this is overkill for a simple
form.