### PR TITLE
UserNormalizer checks data type is object

### DIFF
--- a/src/Normalizers/UserNormalizer.php
+++ b/src/Normalizers/UserNormalizer.php
@@ -34,7 +34,7 @@ class UserNormalizer extends SerializerAwareNormalizer implements NormalizerInte
 
     public function supportsNormalization($data, $format = null)
     {
-        return get_class($data) === 'Base\\User\\Entities\\User';
+        return is_object($data) && get_class($data) === 'Base\\User\\Entities\\User';
     }
 
     public function denormalize($data, $class, $format = null, array $context = [])


### PR DESCRIPTION
UserNormalizer::supportsNormalization checks that an object has been
passed before calling get_class.

This fixes warnings raised on the NCT website where the UserNormalizer
can be passed a null or empty array.